### PR TITLE
Ensure masses are synced to the device

### DIFF
--- a/dlext/src/LAMMPSView.cpp
+++ b/dlext/src/LAMMPSView.cpp
@@ -16,7 +16,7 @@ LAMMPSView::LAMMPSView(LAMMPS_NS::LAMMPS* lmp)
 #ifdef LMP_KOKKOS
     if (has_kokkos_cuda_enabled()) {
         // Since there's is no MASS_MASK, we need to make sure
-        // they are available on the device.
+        // masses are available on the device.
         atom_kokkos_ptr()->k_mass.sync_device();
     }
 #endif

--- a/dlext/src/LAMMPSView.cpp
+++ b/dlext/src/LAMMPSView.cpp
@@ -12,7 +12,15 @@ namespace dlext
 
 LAMMPSView::LAMMPSView(LAMMPS_NS::LAMMPS* lmp)
     : Pointers(lmp)
-{ }
+{
+#ifdef LMP_KOKKOS
+    if (has_kokkos_cuda_enabled()) {
+        // Since there's is no MASS_MASK, we need to make sure
+        // they are available on the device.
+        atom_kokkos_ptr()->k_mass.sync_device();
+    }
+#endif
+}
 
 Atom* LAMMPSView::atom_ptr() const { return lmp->atom; }
 AtomKokkos* LAMMPSView::atom_kokkos_ptr() const { return lmp->atomKK; }


### PR DESCRIPTION
Not all simulations require masses to be available on the device (it depends mainly on the fixes used), so we should ensure that they are synced to the device.

@ndtrung81