### PR TITLE
Expose FixDLExt's view

### DIFF
--- a/dlext/include/FixDLExt.h
+++ b/dlext/include/FixDLExt.h
@@ -39,9 +39,10 @@ public:
     int setmask() override;
     void post_force(int) override;
     void set_callback(DLExtCallback& cb);
+    SPtr<LAMMPSView> get_view() const;
 
 private:
-    std::unique_ptr<LAMMPSView> view;
+    SPtr<LAMMPSView> view;
     DLExtCallback callback = [](TimeStep) { };
 };
 

--- a/dlext/include/LAMMPSView.h
+++ b/dlext/include/LAMMPSView.h
@@ -14,6 +14,8 @@ namespace LAMMPS_NS
 namespace dlext
 {
 
+using namespace cxx11;
+
 // { // Aliases
 
 const auto kOnHost = ExecutionSpace::Host;

--- a/dlext/src/FixDLExt.cpp
+++ b/dlext/src/FixDLExt.cpp
@@ -26,7 +26,7 @@ FixDLExt::FixDLExt(LAMMPS* lmp, int narg, char** arg)
     if (bad_args)
         error->all(FLERR, "Illegal fix dlext command");
 
-    view = cxx11::make_unique<LAMMPSView>(lmp);
+    view = std::make_shared<LAMMPSView>(lmp);
     kokkosable = view->has_kokkos_cuda_enabled();
     atomKK = dynamic_cast<AtomKokkos*>(atom);
     execution_space = (on_host || !kokkosable) ? kOnHost : kOnDevice;
@@ -37,6 +37,7 @@ FixDLExt::FixDLExt(LAMMPS* lmp, int narg, char** arg)
 int FixDLExt::setmask() { return FixConst::POST_FORCE; }
 void FixDLExt::post_force(int) { callback(update->ntimestep); }
 void FixDLExt::set_callback(DLExtCallback& cb) { callback = cb; }
+SPtr<LAMMPSView> FixDLExt::get_view() const { return view; }
 
 } // dlext
 } // LAMMPS_NS

--- a/include/cxx11utils.h
+++ b/include/cxx11utils.h
@@ -23,14 +23,17 @@ template <typename T>
 using SPtr = std::shared_ptr<T>;
 
 template <typename T>
+using UPtr = std::unique_ptr<T>;
+
+template <typename T>
 inline void maybe_unused(T&&)
 { }
 
 // `make_unique` for C++11
 template <typename T, typename... Args>
-std::unique_ptr<T> make_unique(Args&&... args)
+UPtr<T> make_unique(Args&&... args)
 {
-    return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+    return UPtr<T>(new T(std::forward<Args>(args)...));
 }
 
 }  // namespace cxx11

--- a/python/lammps_dlext.cpp
+++ b/python/lammps_dlext.cpp
@@ -46,6 +46,7 @@ void export_FixDLExt(py::module& m)
             return cxx11::make_unique<FixDLExt>(lmp_ptr, narg, cargs.data());
         }))
         .def("set_callback", &FixDLExt::set_callback)
+        .def_property_readonly("view", &FixDLExt::get_view)
         ;
 }
 


### PR DESCRIPTION
This should make the code for the lammps backend in pysages slightly simpler.