### PR TITLE
Export `map_array` property as `tags_map`

### DIFF
--- a/dlext/include/LAMMPSView.h
+++ b/dlext/include/LAMMPSView.h
@@ -24,7 +24,7 @@ const auto kOnDevice = ExecutionSpace::Device;
 // } // Aliases
 
 constexpr unsigned int DLEXT_MASK = (
-    X_MASK | V_MASK | F_MASK | TAG_MASK | TYPE_MASK | MASK_MASK | IMAGE_MASK
+    X_MASK | V_MASK | F_MASK | TAG_MASK | TYPE_MASK | MASK_MASK | MAP_MASK | IMAGE_MASK
 );
 
 //! LAMMPSView is a wrapper around a LAMMPS* instance which provides convenience methods

--- a/dlext/src/FixDLExt.cpp
+++ b/dlext/src/FixDLExt.cpp
@@ -26,6 +26,12 @@ FixDLExt::FixDLExt(LAMMPS* lmp, int narg, char** arg)
     if (bad_args)
         error->all(FLERR, "Illegal fix dlext command");
 
+    if (!atom->tag_enable)
+        error->all(FLERR, "Fix dlext requires atoms to have IDs");
+
+    if (atom->map_style != Atom::MAP_ARRAY)
+        error->all(FLERR, "Fix dlext requires to map atoms as arrays");
+
     view = std::make_shared<LAMMPSView>(lmp);
     kokkosable = view->has_kokkos_cuda_enabled();
     atomKK = dynamic_cast<AtomKokkos*>(atom);

--- a/dlext/src/LAMMPSView.cpp
+++ b/dlext/src/LAMMPSView.cpp
@@ -18,6 +18,9 @@ LAMMPSView::LAMMPSView(LAMMPS_NS::LAMMPS* lmp)
         // Since there's is no MASS_MASK, we need to make sure
         // masses are available on the device.
         atom_kokkos_ptr()->k_mass.sync_device();
+        // On the other hand, MAP_MASK exists, but it's never used
+        // within any of the synchronizations methods.
+        atom_kokkos_ptr()->k_map_array.sync_device();
     }
 #endif
 }
@@ -45,6 +48,7 @@ void LAMMPSView::synchronize(ExecutionSpace requested_space)
 {
     if (lmp->kokkos) {
         atom_kokkos_ptr()->sync(try_pick(requested_space), DLEXT_MASK);
+        atom_kokkos_ptr()->k_map_array.sync_device();
     }
 }
 

--- a/python/dlext/__init__.py
+++ b/python/dlext/__init__.py
@@ -15,6 +15,7 @@ from ._api import (  # noqa: F401 # pylint: disable=E0401
     masses,
     positions,
     tags,
+    tags_map,
     types,
     velocities,
     # Other attributes

--- a/python/lammps_dlext.cpp
+++ b/python/lammps_dlext.cpp
@@ -54,7 +54,7 @@ PYBIND11_MODULE(_api, m)
 {
     // We want to display the members of the module as `lammps.dlext.x`
     // instead of `lammps.dlext._api.x`.
-    auto module_name = m.attr("__name__");
+    auto module_name = py::str(m.attr("__name__"));
     m.attr("__name__") = "lammps.dlext";
 
     // Enums
@@ -74,6 +74,7 @@ PYBIND11_MODULE(_api, m)
     m.def("forces", enpycapsulate<&forces>);
     m.def("images", enpycapsulate<&images>);
     m.def("tags", enpycapsulate<&tags>);
+    m.def("tags_map", enpycapsulate<&tags_map>);
     m.def("types", enpycapsulate<&types>);
 
     // Other attributes

--- a/python/lammps_dlext.cpp
+++ b/python/lammps_dlext.cpp
@@ -54,7 +54,7 @@ PYBIND11_MODULE(_api, m)
 {
     // We want to display the members of the module as `lammps.dlext.x`
     // instead of `lammps.dlext._api.x`.
-    auto module_name = py::str(m.attr("__name__"));
+    py::str module_name = m.attr("__name__");
     m.attr("__name__") = "lammps.dlext";
 
     // Enums


### PR DESCRIPTION
And restrict `FixDLExt` to LAMMPS instances that use array mapped IDs (commands `atom_modify map yes` or `atom_modify map array` within LAMMPS).

CC @ndtrung81