### PR TITLE
Add mechanism to automatically bind to simulation from python

### DIFF
--- a/cmake/Modules/FindLAMMPSTools.cmake
+++ b/cmake/Modules/FindLAMMPSTools.cmake
@@ -278,9 +278,9 @@ fetch_lammps(${LAMMPS_tag})
 
 if(NOT CMAKE_BUILD_TYPE)
     if(${LAMMPS_VERSION} GREATER 20190618)
-        set(CMAKE_BUILD_TYPE Release CACHE STRING "Type of build" FORCE)
-    else()
         set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING "Type of build" FORCE)
+    else()
+        set(CMAKE_BUILD_TYPE Release CACHE STRING "Type of build" FORCE)
     endif()
 endif()
 

--- a/dlext/include/FixDLExt.h
+++ b/dlext/include/FixDLExt.h
@@ -39,12 +39,12 @@ public:
     int setmask() override;
     void post_force(int) override;
     void set_callback(DLExtCallback& cb);
-    SPtr<LAMMPSView> get_view() const;
 
 private:
-    SPtr<LAMMPSView> view;
     DLExtCallback callback = [](TimeStep) { };
 };
+
+void register_FixDLExt(LAMMPS* lmp);
 
 }  // namespace dlext
 }  // namespace LAMMPS_NS

--- a/dlext/include/LAMMPSView.h
+++ b/dlext/include/LAMMPSView.h
@@ -4,6 +4,7 @@
 #ifndef LAMMPSVIEW_H_
 #define LAMMPSVIEW_H_
 
+#include "accelerator_kokkos.h"
 #include "atom_masks.h"
 #include "cxx11utils.h"
 #include "dlpack/dlpack.h"
@@ -44,8 +45,6 @@ public:
     //! The device id where this class instances are being executed
     int device_id() const;
 
-    bool has_kokkos_cuda_enabled() const;
-
     // Convenience methods for retriving the number of particles
     int local_particle_number() const;
     bigint global_particle_number() const;
@@ -56,6 +55,12 @@ public:
 private:
     ExecutionSpace try_pick(ExecutionSpace requested_space) const;
 };
+
+inline bool has_kokkos_cuda_enabled(LAMMPS* lmp)
+{
+    bool has_cuda = strcmp(LMPDeviceType::name(), "Cuda") == 0;
+    return has_cuda & (lmp->kokkos != nullptr);
+}
 
 }  // namespace dlext
 }  // namespace LAMMPS_NS

--- a/dlext/src/LAMMPSView.cpp
+++ b/dlext/src/LAMMPSView.cpp
@@ -14,7 +14,7 @@ LAMMPSView::LAMMPSView(LAMMPS_NS::LAMMPS* lmp)
     : Pointers(lmp)
 {
 #ifdef LMP_KOKKOS
-    if (has_kokkos_cuda_enabled()) {
+    if (has_kokkos_cuda_enabled(lmp)) {
         // Since there's is no MASS_MASK, we need to make sure
         // masses are available on the device.
         atom_kokkos_ptr()->k_mass.sync_device();
@@ -35,12 +35,6 @@ DLDeviceType LAMMPSView::device_type(ExecutionSpace requested_space) const
 
 int LAMMPSView::device_id() const { return 0; }  // TODO: infer this from the LAMMPS instance
 
-bool LAMMPSView::has_kokkos_cuda_enabled() const
-{
-    bool has_cuda = strcmp(LMPDeviceType::name(), "Cuda") == 0;
-    return has_cuda & (lmp->kokkos != nullptr);
-}
-
 int LAMMPSView::local_particle_number() const { return atom_ptr()->nlocal; }
 bigint LAMMPSView::global_particle_number() const { return atom_ptr()->natoms; }
 
@@ -54,7 +48,7 @@ void LAMMPSView::synchronize(ExecutionSpace requested_space)
 
 ExecutionSpace LAMMPSView::try_pick(ExecutionSpace requested_space) const
 {
-    return has_kokkos_cuda_enabled() ? requested_space : kOnHost;
+    return has_kokkos_cuda_enabled(lmp) ? requested_space : kOnHost;
 }
 
 }  // dlext

--- a/python/dlext/__init__.py
+++ b/python/dlext/__init__.py
@@ -7,10 +7,10 @@ from ._api import (  # noqa: F401 # pylint: disable=E0401
     kOnDevice,
     kOnHost,
     # Classes
-    FixDLExt,
     LAMMPSView,
     # Methods
     forces,
+    has_kokkos_cuda_enabled,
     images,
     masses,
     positions,
@@ -25,3 +25,8 @@ from ._api import (  # noqa: F401 # pylint: disable=E0401
     kImg2Bits,
     kImgBitSize,
 )
+
+
+class FixDLExt(_api.FixDLExt):
+    def __init__(self, lammps, args = "dlext all dlext space device"):
+        super().__init__(lammps, args)


### PR DESCRIPTION
LAMMPS uses `Modify::fix_map` to add fix instances to a `LAMMPS` instance. We are adding here a `register_FixDLExt` that makes sure that our fix can be found within a LAMMPS' `Modify::fix_map`. We also leverage this on the python side to automatically register our fix.