### PR TITLE
Support virial contribution from FixDLExt

### DIFF
--- a/dlext/include/FixDLExt.h
+++ b/dlext/include/FixDLExt.h
@@ -19,6 +19,7 @@ namespace dlext
 
 using TimeStep = bigint;  // bigint depends on how LAMMPS was built
 using DLExtCallback = std::function<void(TimeStep)>;
+using DLExtSetVirial = std::function<void(double*)>;
 
 // } // Aliases
 
@@ -39,9 +40,11 @@ public:
     int setmask() override;
     void post_force(int) override;
     void set_callback(DLExtCallback& cb);
+    void set_virial_callback(DLExtSetVirial& cb);
 
 private:
     DLExtCallback callback = [](TimeStep) { };
+    DLExtSetVirial setVirial = [](double*) { };
 };
 
 void register_FixDLExt(LAMMPS* lmp);

--- a/dlext/src/FixDLExt.cpp
+++ b/dlext/src/FixDLExt.cpp
@@ -52,10 +52,12 @@ void FixDLExt::post_force(int vflag)
     // invoke callback
     callback(update->ntimestep);
 
-    // TODO: put the callback's virial into this fix's member variable virial[6] (see fix.h)
-    // callback(virial)
+    // put the virial from the bias into this fix's member variable virial[6] (see fix.h)
+    setVirial(virial);
 }
 void FixDLExt::set_callback(DLExtCallback& cb) { callback = cb; }
+
+void FixDLExt::set_virial_callback(DLExtSetVirial& cb) { setVirial = cb; }
 
 void register_FixDLExt(LAMMPS* lmp)
 {

--- a/dlext/src/FixDLExt.cpp
+++ b/dlext/src/FixDLExt.cpp
@@ -32,6 +32,10 @@ FixDLExt::FixDLExt(LAMMPS* lmp, int narg, char** arg)
     if (atom->map_style != Atom::MAP_ARRAY)
         error->all(FLERR, "Fix dlext requires to map atoms as arrays");
 
+    // signal that this fix contributes to the global virial
+    virial_global_flag = 1;
+    thermo_virial = 1;
+
     kokkosable = has_kokkos_cuda_enabled(lmp);
     atomKK = dynamic_cast<AtomKokkos*>(atom);
     execution_space = (on_host || !kokkosable) ? kOnHost : kOnDevice;
@@ -40,7 +44,17 @@ FixDLExt::FixDLExt(LAMMPS* lmp, int narg, char** arg)
 }
 
 int FixDLExt::setmask() { return FixConst::POST_FORCE; }
-void FixDLExt::post_force(int) { callback(update->ntimestep); }
+void FixDLExt::post_force(int vflag) 
+{
+    // virial setup
+    v_init(vflag);
+
+    // invoke callback
+    callback(update->ntimestep);
+
+    // TODO: put the callback's virial into this fix's member variable virial[6] (see fix.h)
+    // callback(virial)
+}
 void FixDLExt::set_callback(DLExtCallback& cb) { callback = cb; }
 
 void register_FixDLExt(LAMMPS* lmp)

--- a/python/lammps_dlext.cpp
+++ b/python/lammps_dlext.cpp
@@ -49,6 +49,7 @@ void export_FixDLExt(py::module& m)
             return static_cast<FixDLExt*>(fix);
         }))
         .def("set_callback", &FixDLExt::set_callback)
+        .def("set_virial_callback", &FixDLExt::set_virial_callback)
         ;
 }
 


### PR DESCRIPTION
This PR intends to add the virial contribution from FixDLExt to the global virial, which is required for NPT simulations where global pressure is computed at every time step. This virial contribution comes from the biasing methods in use from the PySAGES side.